### PR TITLE
CORE-404 Re-enabled ES-1126 as part of the CORE 404 work.

### DIFF
--- a/components/fabs/fabs_current_accounts_comps.rb
+++ b/components/fabs/fabs_current_accounts_comps.rb
@@ -12,7 +12,7 @@ class FabsCurrentAccountsComps
   end
 
   def link_lloyds_banking_group
-    find(:xpath, "//a[text()='Lloyds Banking Group (opens in new tab)']")
+    find(:xpath, "//a[text()='Lloyds (opens in new tab)']")
   end
 
   def link_natwest

--- a/features/fabs_banking.feature
+++ b/features/fabs_banking.feature
@@ -1,8 +1,8 @@
-#@regression @fabs
+@regression @fabs
 Feature: GHBS - FABS page behaviour
   Background:
     Given we open and validate the fabs homepage
-  # Currently blocked by CORE-404
+
   Scenario: ES-1126 - Banking Page and http link validation
     Given we open the Savings options for schools buying option via the Banking and finance category
     When we open and validate the links out of the saving options page

--- a/pages/fabs/fabs_banking_methods.rb
+++ b/pages/fabs/fabs_banking_methods.rb
@@ -110,25 +110,6 @@ class FabsBankingMethods < FabsBasePage
 
     reset_to_current_accounts_via_related_content
 
-    #### Lloyds Banking Group ####
-    # Navigate to the internal Lloyds Banking Group page
-    fabs_current_accounts_comps.link_lloyds_banking_group.click
-    expect(page).to have_current_path(%r{/lloyds-banking-group}, url: true, wait: 10)
-    expect(fabs_buying_option_comps.text_page_heading.text).to include("Lloyds Banking Group")
-
-    # Validate the external Lloyds Banking Group link
-    url_lloyds = "https://www.lloydsbank.com/business/industry-expertise/education.html?WT.ac=lloyds-RM_signature-hub-sectors-page-education"
-    expect(page).to have_link("Visit Lloyds Banking Group’s website", href: url_lloyds)
-    validate_link_reachable(
-      url_lloyds,
-      expected_title: "Education sector | Industry expertise | Lloyds Bank",
-      expected_status: 200,
-      fallback_on: [403],
-      only_run_in: "local"
-    )
-
-    reset_to_current_accounts_via_related_content
-
     #### NatWest ####
     # Navigate to the internal NatWest page
     fabs_current_accounts_comps.link_natwest.click


### PR DESCRIPTION
- Removed final lloyds check as its being changed at the moment.