### PR TITLE
Maintenance - fix ES-1126 renaming of related content to related read…

### DIFF
--- a/components/fabs/fabs_insignis_savings_platform_comps.rb
+++ b/components/fabs/fabs_insignis_savings_platform_comps.rb
@@ -10,6 +10,6 @@ class FabsInsignisSavingsPlatformComps
 
   # Inputs
   def link_related_content_current_accounts_for_schools
-    find(:xpath, "//h2[text()='Related content']/following-sibling::ul/li/a[text()='Current accounts for schools']")
+    find(:xpath, "//h2[text()='Related reading']/following-sibling::ul/li/a[text()='Current accounts for schools']")
   end
 end

--- a/components/fabs/fabs_shared_related_content_comps.rb
+++ b/components/fabs/fabs_shared_related_content_comps.rb
@@ -10,6 +10,6 @@ class FabsSharedRelatedContentComps
 
   # Inputs
   def link_related_content_current_accounts_for_schools
-    find(:xpath, "//h2[text()='Related content']/following-sibling::ul/li/a[text()='Current accounts for schools']")
+    find(:xpath, "//h2[text()='Related reading']/following-sibling::ul/li/a[text()='Current accounts for schools']")
   end
 end


### PR DESCRIPTION
…ing.

- update ES-646-1 is broken due to (about this/our service) however the code is correct for when CORE-649 is merged in.